### PR TITLE
Fix missing CSS animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,16 @@
       transform: translateY(0);
     }
   }
+
+  /* Added missing pulse animation for animate-glow */
+  @keyframes pulse {
+    0%, 100% {
+      opacity: 0.7;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
 }
 
 /* Optional: Smooth scrollbar styling */


### PR DESCRIPTION
## Summary
- implement the missing `pulse` keyframes used by the `animate-glow` utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851229709f4832ba81c1211d7f5b3f5